### PR TITLE
Fix config load if no user config available

### DIFF
--- a/modules/Core/Environment.psm1
+++ b/modules/Core/Environment.psm1
@@ -1,3 +1,4 @@
+# Replaces enviroment variables with their given values
 function Format-EnvironmentVariables {
     [cmdletbinding()]
     param(
@@ -18,6 +19,32 @@ function Format-EnvironmentVariables {
             }
         }
 
-        return $content.Replace("\","/")
+        return $content
+    }
+}
+
+# Ensures paths are correctly formatted
+function Format-Paths {
+    [cmdletbinding()]
+    param(
+        [parameter(
+            Mandatory                       = $false,
+            ValueFromPipeline               = $true,
+            ValueFromPipelineByPropertyName = $true
+            )]
+        [string]$content
+    )
+    process {
+        $content | Select-String -Pattern '[a-zA-Z]:[\\\/](?:[a-zA-Z0-9]+[\\\/])*([a-zA-Z0-9]+\.*)' -AllMatches | ForEach-Object {
+            $_.matches | ForEach-Object {
+                $value = (Test-Path $_.groups[0]) `
+                    ? (Convert-Path $_.groups[0]) `
+                    : $_.groups[0]
+
+                $content = $content.Replace($_.groups[0], $value)
+            }
+        }
+
+        return $content
     }
 }

--- a/modules/Prompt/Prompt.psm1
+++ b/modules/Prompt/Prompt.psm1
@@ -1,5 +1,4 @@
-function Invoke-Prompt {
-    $config = (Get-Config).modules?.Prompt?.config
+function Invoke-Prompt($config) {
     switch($config.prompt) {
         "none" {
             return

--- a/pwsh.yaml
+++ b/pwsh.yaml
@@ -1,3 +1,14 @@
+#####################################################################
+# PWSH YAML CONFIGURATION                                           #
+#   This is the default configuration file for the PWSH profile.    #
+#   It will be processed by the PWSH profile scripts to determine   #
+#   which modules to load into the session as well as configure     #
+#   individual features.                                            #
+#                                                                   #
+# ENVIRONMENT VARIABLES                                             #
+#   Environment variables can be injected using the ${VAR} syntax.  #
+#####################################################################
+
 # Unique configurations for each module in ./modules
 # "disabled"   => The module will not be loaded
 # "config"     => The module will be loaded with the given configuration
@@ -93,5 +104,6 @@ modules:
     disabled: false
     config:
 
+# Paths to add to the session
 paths:
 - ${HOME}/tools


### PR DESCRIPTION
Removes:
* `ConvertTo-Object` (Unused function of questionable use)
* `pwshenv.ps1` reference as it makes no sense to set up environment variables this way

Changes:
* Move the path 'fix' when formatting config into separate `Format-Paths` function
* Simplify `Get-Config` function as much as possible
  * Still has nasty temporary file, but it is at least removed after use now
  * Reduce number of `Get-Config` calls on init since it can get potentially expensive

Adds:
* Adds a description to the top of the default `pwsh.yaml` config